### PR TITLE
vanish blocks caffeinated

### DIFF
--- a/client/tiles/vanish/VanishEffect.tscn
+++ b/client/tiles/vanish/VanishEffect.tscn
@@ -42,7 +42,7 @@ tracks/0/path = NodePath("Sprite:modulate")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 1, 3, 4),
+"times": PackedFloat32Array(0, 0.3, 2.295, 2.595),
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 0,
 "values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
@@ -54,7 +54,7 @@ tracks/1/path = NodePath("StaticBody:process_mode")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0, 1, 3, 4),
+"times": PackedFloat32Array(0, 0.3, 2.295, 2.595),
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 1,
 "values": [0, 4, 0, 0]
@@ -66,7 +66,7 @@ tracks/2/path = NodePath(".")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"times": PackedFloat32Array(2.9, 4),
+"times": PackedFloat32Array(2.195, 2.595),
 "transitions": PackedFloat32Array(1, 1),
 "values": [{
 "args": [],


### PR DESCRIPTION
Vanish block animation sped up. Matches PR2 timing.

Vanish blocks linger too long, making it too difficult to get passed walls of them and too easy to use as platforms.