### PR TITLE
Fixed line saving and reloading on game exit

### DIFF
--- a/client/pages/editor/LevelDecoder.gd
+++ b/client/pages/editor/LevelDecoder.gd
@@ -41,6 +41,6 @@ func decode_lines(objects: Array, holder: Node2D) -> void:
 		line.begin_cap_mode = Line2D.LINE_CAP_ROUND
 		line.default_color = Color("FFFFFF") # Color(object.properties.color)
 		line.width = 10 # object.properties.thickness
-		for point in object.polyline:
+		for point in str_to_var(object.polyline):
 			line.add_point(Vector2(point.x, point.y))
 		holder.add_child(line)

--- a/client/pages/editor/LevelEncoder.gd
+++ b/client/pages/editor/LevelEncoder.gd
@@ -62,7 +62,7 @@ func encode_lines(node: Node2D) -> Array:
 		var object = {
 			"x": line.position.x,
 			"y": line.position.y,
-			"polyline": line.points,
+			"polyline": var_to_str(line.points),
 			"properties": {
 				"color": "FFFFFF",
 				"thickness": 10


### PR DESCRIPTION
Fixed a bug where the line would not save in the correct format so when closing and reopening the game the line data would be lost. On the web version it merely deleted the line but on client it would crash the game.
Note GitHub thinks I changed both files entirely, but I only actually changed 1 line in each of the 2 files. Line 44 in Decoder and Line 65 in Encoder.