### PR TITLE
Fixes for Safety Nets, Start and Teleport Respecting Rotation, and more

### DIFF
--- a/client/character/Character.gd
+++ b/client/character/Character.gd
@@ -45,6 +45,7 @@ var target_rotation: float = 0
 var rotate_speed: float = 0.05
 var item: Node2D
 var last_safe_position = Vector2(0, 0)
+var last_safe_layer: Node
 var frozen_timer: float = 0.0
 var last_velocity: Vector2
 var last_collision_normal: Vector2
@@ -299,12 +300,15 @@ func end_lightbreak():
 func _on_body_shape_entered(body_rid: RID, body: Node2D, _body_shape_index: int, _local_shape_index: int):
 	if body.get_class() != "TileMap":
 		return
-	incoporeal_rids.push_back({"body_rid": body_rid, "body": body})
+
+	incoporeal_rids.push_back({"body_rid": body_rid, "body": body, "coords":body.get_coords_for_body_rid(body_rid)})
 
 
 func _on_body_shape_exited(body_rid: RID, body: Node2D, _body_shape_index: int, _local_shape_index: int):
 	incoporeal_rids = incoporeal_rids.filter(func(dict): return dict["body_rid"] != body_rid)
 
+func force_remove_body_shape(coords: Vector2i):
+	incoporeal_rids = incoporeal_rids.filter(func(dict): return dict["coords"] != coords)
 
 # Interact with tiles like water, switches, etc
 func interact_with_incoporeal_tiles():
@@ -355,6 +359,8 @@ func interact_with_solid_tiles() -> bool:
 			if game.tiles.is_safe(tile_type) and tilemap.name.contains("gear") == false:
 				var centre_safe_block = Vector2(coords.x * Settings.tile_size_half.x * 2 + Settings.tile_size_half.x, coords.y * Settings.tile_size_half.y * 2 + Settings.tile_size_half.y).rotated(tilemap.global_rotation)
 				last_safe_position = centre_safe_block - (Vector2(0,(1 * Settings.tile_size.y) - 22)).rotated(tilemap.global_rotation + rotation)
+				var layers = tilemap.get_node("../../")
+				last_safe_layer = layers.get_node(str(str(tilemap.get_parent().name)))
 	
 	# blow up tiles when sun lightbreaking
 	if lightbreak_direction.length() > 0 && lightbreak_fire_power > 0:

--- a/client/character/Character.gd
+++ b/client/character/Character.gd
@@ -138,7 +138,6 @@ func _physics_process(delta):
 			jumped = false
 		# Fastfall; if down pressed while not on floor, fall faster
 		if Input.is_action_pressed("down"):
-			print("FASTFALL VELOCITY: ", FASTFALL_VELOCITY.rotated(rotation))
 			velocity += FASTFALL_VELOCITY.rotated(rotation)
 			jumped = false
 		if not jumped:
@@ -328,7 +327,7 @@ func interact_with_solid_tiles() -> bool:
 	var tilemap = collision.get_collider()
 	if tilemap.get_class() != "TileMap":
 		return false
-	
+
 	var normal = collision.get_normal().rotated(-rotation)
 	var rid = collision.get_collider_rid()
 	var coords = tilemap.get_coords_for_body_rid(rid)
@@ -353,8 +352,9 @@ func interact_with_solid_tiles() -> bool:
 			game.tiles.on("top", tile_type, self, tilemap, coords)
 			game.tiles.on("any_side", tile_type, self, tilemap, coords)
 			game.tiles.on("stand", tile_type, self, tilemap, coords)
-			if game.tiles.is_safe(tile_type):
-				last_safe_position = Vector2(floor(position.x / Settings.tile_size.x) * Settings.tile_size.x, position.y) - Vector2(-Settings.tile_size_half.x, Settings.tile_size_half.y).rotated(rotation)
+			if game.tiles.is_safe(tile_type) and tilemap.name.contains("gear") == false:
+				var centre_safe_block = Vector2(coords.x * Settings.tile_size_half.x * 2 + Settings.tile_size_half.x, coords.y * Settings.tile_size_half.y * 2 + Settings.tile_size_half.y).rotated(tilemap.global_rotation)
+				last_safe_position = centre_safe_block - (Vector2(0,(1 * Settings.tile_size.y) - 22)).rotated(tilemap.global_rotation + rotation)
 	
 	# blow up tiles when sun lightbreaking
 	if lightbreak_direction.length() > 0 && lightbreak_fire_power > 0:

--- a/client/pages/game/Game.gd
+++ b/client/pages/game/Game.gd
@@ -50,7 +50,7 @@ func activate():
 	var character = CHARACTER.instantiate()
 	var layer = layers.get_node(start_option.layer_name)
 	var player_holder = layer.get_node("Players")
-	character.position = (start_option.coords * Settings.tile_size) + Settings.tile_size_half
+	character.position = Vector2((start_option.coords * Settings.tile_size) + Settings.tile_size_half).rotated(start_option.tilemap.global_rotation if start_option.tilemap else 0)
 	character.active = true
 	player_holder.add_child(character)
 	character.set_depth(round(layer.follow_viewport_scale * 10))

--- a/client/pages/tester/Tester.gd
+++ b/client/pages/tester/Tester.gd
@@ -26,7 +26,7 @@ func init(level: Dictionary):
 	var character = CHARACTER.instantiate()
 	var layer = layers.get_node(start_option.layer_name)
 	var player_holder = layer.get_node("Players")
-	character.position = (start_option.coords * Settings.tile_size) + Settings.tile_size_half
+	character.position = Vector2((start_option.coords * Settings.tile_size) + Settings.tile_size_half).rotated(start_option.tilemap.global_rotation if start_option.tilemap else 0)
 	character.active = true
 	player_holder.add_child(character)
 	character.set_depth(round(layer.follow_viewport_scale * 10))

--- a/client/tiles/SafetyNet.gd
+++ b/client/tiles/SafetyNet.gd
@@ -10,3 +10,10 @@ func init():
 func safety_net(player: Node2D, tilemap: TileMap, coords: Vector2i):
 	player.position.x = player.last_safe_position.x
 	player.position.y = player.last_safe_position.y
+
+	if (player.last_safe_layer != null and (player.last_safe_layer.get_node("Players") != player.get_parent())):
+		player.get_parent().remove_child(player)
+		player.last_safe_layer.get_node("Players").add_child(player)
+		player.set_depth(round(player.last_safe_layer.follow_viewport_scale * 10))
+		player.force_remove_body_shape(coords)
+		

--- a/client/tiles/Start.gd
+++ b/client/tiles/Start.gd
@@ -15,7 +15,8 @@ func activate_tilemap(tilemap: TileMap) -> void:
 	for coords in coord_list:
 		var start_option = {
 			"layer_name": str(tilemap.get_parent().name),
-			"coords": coords
+			"coords": coords,
+			"tilemap": tilemap,
 		}
 		start_options.push_back(start_option)
 
@@ -34,5 +35,5 @@ static func get_next_start_option() -> Dictionary:
 	else:
 		return {
 			"layer_name": "L1",
-			"coords": Vector2i(0, 0)
+			"coords": Vector2i(0, 0),
 		}

--- a/client/tiles/Start.gd
+++ b/client/tiles/Start.gd
@@ -36,4 +36,5 @@ static func get_next_start_option() -> Dictionary:
 		return {
 			"layer_name": "L1",
 			"coords": Vector2i(0, 0),
+			"tilemap": null,
 		}

--- a/client/tiles/gear/Gear.gd
+++ b/client/tiles/gear/Gear.gd
@@ -3,6 +3,8 @@ class_name Gear
 
 var RotationController = preload("res://tiles/gear/RotationController.gd")
 
+func init():
+	is_safe = false
 
 func activate_tilemap(tile_map: TileMap):
 	var gear_coord_list = tile_map.get_used_cells_by_id(0, 0, Vector2i(4, 3))

--- a/client/tiles/gear/Gear.gd
+++ b/client/tiles/gear/Gear.gd
@@ -26,6 +26,7 @@ func activate_tilemap(tile_map: TileMap):
 		# Create sub tilemap
 		var sub_tile_map = TileMap.new()
 		sub_tile_map.tile_set = tile_map.tile_set
+		sub_tile_map.name = "gear_" + str(gear_coords) + "_tilemap"
 		sub_tile_map.set_cell(0, Vector2i(0, 0), 0, Vector2i(4, 3))
 		sub_tile_map.position = -Settings.tile_size_half # doesn't work, workaround in RotationController
 		sub_tile_map.collision_animatable = true

--- a/client/tiles/teleport/Teleport.gd
+++ b/client/tiles/teleport/Teleport.gd
@@ -20,7 +20,8 @@ func activate_tilemap(tilemap: TileMap) -> void:
 		var position = {
 			"layer_name": str(tilemap.get_parent().name),
 			"coords": coords,
-			"color": color
+			"color": color,
+			"tilemap": tilemap
 		}
 		positions.push_back(position)
 
@@ -44,9 +45,10 @@ func teleport(player: Node2D, tilemap: TileMap, coords: Vector2i) -> void:
 	var next_position = get_next_position(source_position)
 	var layers = tilemap.get_node("../../")
 	var layer = layers.get_node(next_position.layer_name)
-	var source_block_position = Vector2(coords * Settings.tile_size + Settings.tile_size_half)
-	var next_block_position = Vector2(next_position.coords * Settings.tile_size + Settings.tile_size_half)
-	var dist = player.position - source_block_position
+	var source_block_position = Vector2(coords * Settings.tile_size + Settings.tile_size_half).rotated(tilemap.global_rotation)
+	var next_block_position = Vector2(next_position.coords * Settings.tile_size + Settings.tile_size_half).rotated(next_position.tilemap.global_rotation)
+	var dist = (player.position - source_block_position).rotated(next_position.tilemap.global_rotation)
+	
 	player.get_parent().remove_child(player)
 	layer.get_node("Players").add_child(player)
 	player.position = next_block_position + dist

--- a/client/tiles/vanish/Vanish.gd
+++ b/client/tiles/vanish/Vanish.gd
@@ -7,7 +7,7 @@ const VANISH_EFFECT = preload("res://tiles/vanish/VanishEffect.tscn")
 func init():
 	matter_type = Tile.SOLID
 	any_side.push_back(vanish)
-
+	is_safe = false
 
 func vanish(player: Node2D, tilemap: TileMap, coords: Vector2i):
 	var atlas_coords = tilemap.get_cell_atlas_coords(0, coords)


### PR DESCRIPTION
Safety Nets:
- Vanish, Gear Block, and any blocks connected to a gear are now considered unsafe.
- The calculation used to find where the player should respawn for a safe tile has been fixed
- Safeties can now respawn you across layers

Misc:
- Added a way to force remove an area from incoporeal_rids, this is needed because when swapping the player from one layer to another area leave is not always triggered and therefore the block would cause an infinite "loop" of trying to respawn the player, essentially freezing him in place (for nets at least, for other blocks it'd still because that type to keep getting triggered)

Start and Teleport:
- My commit says vanish, but I mean start and teleport; Both blocks now respect the tilemaps rotation.