### PR TITLE
Vanish can disappear early and variable animation values

### DIFF
--- a/client/tiles/vanish/Vanish.gd
+++ b/client/tiles/vanish/Vanish.gd
@@ -3,6 +3,15 @@ class_name Vanish
 
 const VANISH_EFFECT = preload("res://tiles/vanish/VanishEffect.tscn")
 
+var anim_fading_time = float(0.3)   #Default 0.3
+var anim_gone_time = float(1.995)   #Default 1.995
+var anim_unfading_time = float(0.3) #Default 0.3
+
+var anim_fading_end_time = float(anim_fading_time + anim_gone_time)
+var anim_unfading_end_time = float(anim_fading_end_time + anim_unfading_time)
+var anim_player
+var anim
+var anim_timeline_position
 
 func init():
 	matter_type = Tile.SOLID
@@ -10,14 +19,31 @@ func init():
 	is_safe = false
 
 func vanish(player: Node2D, tilemap: TileMap, coords: Vector2i):
-	var atlas_coords = tilemap.get_cell_atlas_coords(0, coords)
-	if atlas_coords == Vector2i(-1, -1):
-		return
+	if tilemap.get_cell_alternative_tile(0,coords) != 0: #Only pass if statement when the Vanish Block is in default tile state
+		anim_timeline_position = anim_player.get_current_animation_position()
+		if anim_timeline_position > anim_fading_time + anim_gone_time: #Check if Vanish is mid-appear phase to start despawning it
+			anim_player.seek(max(0, anim_fading_time + anim_gone_time + anim_unfading_time - anim_timeline_position))
+		return #Return if vanish is currently despawning
 	
+	var atlas_coords = tilemap.get_cell_atlas_coords(0, coords)
+	tilemap.set_cell(0, coords, 0, atlas_coords, 1)
 	var tile_atlas = tilemap.tile_set.get_source(0).texture
 	var vanish_effect = VANISH_EFFECT.instantiate()
 	vanish_effect.position = coords * Settings.tile_size
 	tilemap.add_child(vanish_effect)
 	vanish_effect.init(tile_atlas, atlas_coords, tilemap, coords)
-
-	tilemap.set_cell(-1, coords)
+	
+	anim_player = vanish_effect.get_node("AnimationPlayer")
+	anim = anim_player.get_animation("vanish")
+	anim.length = anim_unfading_end_time #Total length
+	#Insert Keys into Sprite modulate Track
+	anim.track_insert_key(0,float(0),Color(1, 1, 1, 1),1) #Start Disappear
+	anim.track_insert_key(0,anim_fading_time,Color(1, 1, 1, 0), 1) #End Disappear
+	anim.track_insert_key(0,anim_fading_end_time,Color(1, 1, 1, 0),1) #Start Reappear
+	anim.track_insert_key(0,anim_unfading_end_time,Color(1, 1, 1, 1),1) #End Reappear
+	#Insert Keys into Node Call Functions Track
+	anim.track_insert_key(2,anim_fading_end_time - 0.1,{"method" : "_avoid_clobber", "args" : []})
+	anim.track_insert_key(2,anim_fading_time,{"method" : "_on_disappear", "args" : []})
+	anim.track_insert_key(2,anim_fading_end_time,{"method" : "_on_reappear", "args" : []})
+	anim.track_insert_key(2,anim_unfading_end_time,{"method" : "_on_anim_complete", "args" : []})
+	

--- a/client/tiles/vanish/VanishEffect.gd
+++ b/client/tiles/vanish/VanishEffect.gd
@@ -1,13 +1,11 @@
 extends Node2D
 
-@onready var static_body = $StaticBody
 @onready var sprite = $Sprite
 @onready var area = $Area
 @onready var animation_player = $AnimationPlayer
 var _tile_map: TileMap
 var _coords: Vector2i
 var _atlas_coords: Vector2i
-
 
 func init(atlas: Texture, atlas_coords: Vector2i, tile_map: TileMap, coords: Vector2i):
 	_tile_map = tile_map
@@ -19,17 +17,21 @@ func init(atlas: Texture, atlas_coords: Vector2i, tile_map: TileMap, coords: Vec
 	
 	var depth = Helpers.get_depth(tile_map)
 	var layer = Helpers.to_bitmask_32(depth * 2)
-	static_body.collision_layer = layer 
-	static_body.collision_mask = layer
 	area.collision_layer = layer
 	area.collision_mask = layer
 
-
 func _avoid_clobber():
 	if area.has_overlapping_bodies():
-		animation_player.seek(2.0)
+		var _anim = animation_player.get_animation("vanish")
+		var reset_to_time = _anim.track_get_key_time(0,3) - 0.75 * _anim.track_get_key_time(0,2) #Set to where 0.75 of gone_time remains
+		animation_player.seek(reset_to_time)
 
+func _on_disappear():
+	_tile_map.set_cell(0, _coords, 0, _atlas_coords,4)
+	
+func _on_reappear():
+	_tile_map.set_cell(0, _coords, 0, _atlas_coords,1)
 
 func _on_anim_complete():
-	_tile_map.set_cell(0, _coords, 0, _atlas_coords)
+	_tile_map.set_cell(0, _coords, 0, _atlas_coords,0)
 	queue_free()

--- a/client/tiles/vanish/VanishEffect.tscn
+++ b/client/tiles/vanish/VanishEffect.tscn
@@ -30,6 +30,17 @@ tracks/1/keys = {
 "update": 1,
 "values": [0]
 }
+tracks/2/type = "method"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath(".")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(),
+"transitions": PackedFloat32Array(),
+"values": []
+}
 
 [sub_resource type="Animation" id="Animation_3dgkk"]
 resource_name = "vanish"
@@ -42,10 +53,10 @@ tracks/0/path = NodePath("Sprite:modulate")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.3, 2.295, 2.595),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
+"times": PackedFloat32Array(),
+"transitions": PackedFloat32Array(),
 "update": 0,
-"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+"values": []
 }
 tracks/1/type = "value"
 tracks/1/imported = false
@@ -54,10 +65,10 @@ tracks/1/path = NodePath("StaticBody:process_mode")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.3, 2.295, 2.595),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
 "update": 1,
-"values": [0, 4, 0, 0]
+"values": [0]
 }
 tracks/2/type = "method"
 tracks/2/imported = false
@@ -66,15 +77,9 @@ tracks/2/path = NodePath(".")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"times": PackedFloat32Array(2.195, 2.595),
-"transitions": PackedFloat32Array(1, 1),
-"values": [{
-"args": [],
-"method": &"_avoid_clobber"
-}, {
-"args": [],
-"method": &"_on_anim_complete"
-}]
+"times": PackedFloat32Array(),
+"transitions": PackedFloat32Array(),
+"values": []
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_lx6mq"]


### PR DESCRIPTION
Vanish uses variables in code instead of pre-baked inspector values for the Vanish Effect animation. Easy to customize.
Vanish Block's tile is used for collision while Vanish Effect is active (instead of setting tile to Layer -1 and using a Vanish Effect Collider box when the Vanish is spawning.)
Push Blocks can no longer be pushed behind Vanish Blocks.
Vanish Blocks start disappearing if they are touched while respawning (timeline code from Camer999).

Issues:

Bump animation does not work very well with Vanish Block. (The way it was previously done, bumps would not appear at all.).
Note: In PR2, Vanish Blocks can be bumped and have their fading animation follow the bump effect.