### PR TITLE
(Not sure if this was intended) Fix workflow to build game-server instead of api

### DIFF
--- a/.github/workflows/build-game-server.yaml
+++ b/.github/workflows/build-game-server.yaml
@@ -26,7 +26,7 @@ jobs:
           go test .
       - name: Build Image
         run: |
-          cd api
+          cd game-server
           docker build -t pr4 --file Dockerfile .
           if [ "$GITHUB_REF_NAME" == "main" ] || [ "$GITHUB_REF_NAME" == "release" ]; then
             tag="$(date +%F-%H-%M)-$GITHUB_REF_NAME-$GITHUB_SHA"

--- a/client/singletons/helpers/Helpers.gd
+++ b/client/singletons/helpers/Helpers.gd
@@ -14,11 +14,11 @@ func get_base_ws_url() -> String:
 		
 	if '--local' in OS.get_cmdline_args() || OS.is_debug_build() || OS.get_environment('PR_ENV') == 'local' || OS.has_feature("editor"):
 		#return 'ws://localhost:8081/ws'
-		return 'ws://dev.platformracing.com/ws'
+		return 'ws://dev.platformracing.com/api/ws'
 	elif '--dev' in OS.get_cmdline_args() || OS.get_environment('PR_ENV') == 'dev':
-		return 'ws://dev.platformracing.com/ws'
+		return 'ws://dev.platformracing.com/api/ws'
 	else:
-		return 'ws://platformracing.com/ws'
+		return 'ws://platformracing.com/api/ws'
 		
 func get_base_url() -> String:
 	if OS.has_feature('web'):
@@ -29,11 +29,11 @@ func get_base_url() -> String:
 		
 	if '--local' in OS.get_cmdline_args() || OS.is_debug_build() || OS.get_environment('PR_ENV') == 'local' || OS.has_feature("editor"):
 		#return 'http://localhost:8080'
-		return 'https://dev.platformracing.com'
+		return 'https://dev.platformracing.com/api'
 	elif '--dev' in OS.get_cmdline_args() || OS.get_environment('PR_ENV') == 'dev':
-		return 'https://dev.platformracing.com'
+		return 'https://dev.platformracing.com/api'
 	else:
-		return 'https://platformracing.com'
+		return 'https://platformracing.com/api'
 
 func _get_current_level_name() -> String:
 	return current_level_name


### PR DESCRIPTION
Hello, 

1. I noticed that your build-game-server.yaml file is currently set to build the "api" folder instead of the "game-server" folder. I’m not sure if this was intentional, but I wanted to point it out in case it wasn’t.

2. Additionally, I was wondering if there’s a way to reach you, perhaps via Discord? I would be very interested in contributing more to PR4 if you’re open to it.

3. Regarding what you mentioned about the Caddy server automatically adding the "api" path, I think what we can do for now is to change the "Helpers.gd" to simply add "api" path at the end for live and dev environment, but not for localhost. What do you think? 

5. Also, I am not sure if "ws://dev.platformracing.com/api/ws" request works so will need your help to double check this. I updated the api to use 8080 port and game-server to use 8081 port.