### PR TITLE
(Not sure if this was intended) Fix workflow to build game-server instead of api

### DIFF
--- a/.github/workflows/build-game-server.yaml
+++ b/.github/workflows/build-game-server.yaml
@@ -26,7 +26,7 @@ jobs:
           go test .
       - name: Build Image
         run: |
-          cd api
+          cd game-server
           docker build -t pr4 --file Dockerfile .
           if [ "$GITHUB_REF_NAME" == "main" ] || [ "$GITHUB_REF_NAME" == "release" ]; then
             tag="$(date +%F-%H-%M)-$GITHUB_REF_NAME-$GITHUB_SHA"

--- a/client/game_client/GameClient.gd
+++ b/client/game_client/GameClient.gd
@@ -208,7 +208,6 @@ func _process(delta: float) -> void:
 				is_live_editing = true
 				cursor_timer.start()
 				var request_editor = parsed_packet.request_editor
-				Session.set_local_edit_id(request_editor.edit_id)
 				
 				var level_data = Marshalls.base64_to_utf8(request_editor.level_data)
 				level_data = JSON.parse_string(level_data)
@@ -246,7 +245,6 @@ func _process(delta: float) -> void:
 					"ret": true,
 					"request_editor": {
 						"level_data": encoded_data,
-						"edit_id": Session.get_local_edit_id()
 					}
 				}
 				send_queue.push_back(data)
@@ -281,7 +279,6 @@ func _process(delta: float) -> void:
 				if is_host:
 					return
 					
-				Session.set_local_edit_id(0)
 				is_live_editing = true
 				cursor_timer.start()
 				is_host = true
@@ -298,7 +295,7 @@ func _process(delta: float) -> void:
 				else:
 					if parsed_packet.editor.user_id != Session.get_username():
 						# Give the illusion that the remote cursor appears same time as the block
-						await get_tree().create_timer(1).timeout
+						await get_tree().create_timer(0.1).timeout
 					emit_signal("receive_level_event", parsed_packet.editor)
 			elif parsed_packet.module == "ResponseRoomModule":
 				var member_id_list: Array[String] = []

--- a/client/pages/editor/Penciler.gd
+++ b/client/pages/editor/Penciler.gd
@@ -8,15 +8,39 @@ const LAYER = preload("res://layers/Layer.tscn")
 @onready var editor_events: Node2D = get_node("../EditorEvents")
 @onready var edit_cursors: Node2D = get_node("../EditorCursorLayer/EditorCursors")
 
+const CLEANUP_INTERVAL = 60  # 600 seconds (1 minutes)
+var last_cleanup_time = 0
+
+var tile_update_timestamps = {}
+
 func _ready():
 	editor_events.connect("level_event", _on_level_event)
 
+func _process(delta: float) -> void:
+	var current_time = Time.get_unix_time_from_system()
+	if current_time - last_cleanup_time >= CLEANUP_INTERVAL:
+		_cleanup_old_timestamps()
+		last_cleanup_time = current_time
 
+func _cleanup_old_timestamps() -> void:
+	var current_time = Time.get_unix_time_from_system()
+	for key in tile_update_timestamps.keys():
+		if current_time - tile_update_timestamps[key] > CLEANUP_INTERVAL:
+			tile_update_timestamps.erase(key)
+		
 func _on_level_event(event: Dictionary) -> void:
 	if event.type == EditorEvents.SET_TILE:
-		var tilemap: TileMap = layers.get_node(event.layer_name + "/TileMap")
 		var coords = Vector2i(event.coords.x, event.coords.y)
-		tilemap.set_cell(0, coords, 0, Helpers.to_atlas_coords(event.block_id))
+		var coords_key = str(coords.x) + "_" + str(coords.y)
+		
+		if event.has("timestamp"):
+			var new_timestamp = event.timestamp
+			
+			if not tile_update_timestamps.has(coords_key) or tile_update_timestamps[coords_key] < new_timestamp:
+				_set_tile(event, coords, coords_key, new_timestamp)
+		else:
+			_set_tile(event, coords, coords_key)
+
 	if event.type == EditorEvents.ADD_LINE:
 		var lines: Node2D = layers.get_node(event.layer_name + "/Lines")
 		var line = Line2D.new()
@@ -29,6 +53,7 @@ func _on_level_event(event: Dictionary) -> void:
 		for point_dict in event.points:
 			converted_points.append(Vector2(point_dict.x, point_dict.y))
 		line.points = converted_points
+
 	if event.type == EditorEvents.ADD_LAYER:
 		print("addlayer: " + event.name)
 		var layer = LAYER.instantiate()
@@ -37,6 +62,7 @@ func _on_level_event(event: Dictionary) -> void:
 		layers.add_child(layer)
 		layer.init(get_parent().tiles)
 		layer_panel.call_deferred("render")
+
 	if event.type == EditorEvents.DELETE_LAYER:
 		print("remlayer: " + event.name)
 		var layer = layers.get_node(event.name)
@@ -44,6 +70,7 @@ func _on_level_event(event: Dictionary) -> void:
 			layers.remove_child(layer)
 			layer.queue_free()
 		layer_panel.call_deferred("render")
+
 	if event.type == EditorEvents.ADD_USERTEXT:
 		var usertextboxes: Node2D = layers.get_node(event.layer_name + "/UserTextboxes")
 		var usertextbox_scene: PackedScene = preload("res://pages/editor/menu/UserTextbox.tscn")
@@ -51,11 +78,21 @@ func _on_level_event(event: Dictionary) -> void:
 		usertextbox.set_usertext_properties(event.usertext, event.font, event.font_size)
 		usertextboxes.add_child(usertextbox)
 		usertextbox.position = Vector2(event.position.x, event.position.y)
+
 	if event.type == EditorEvents.ROTATE_LAYER:
 		var layer = layers.get_node(event.layer_name)
 		layer.get_node("TileMap").rotation_degrees = event.rotation
+
 	if event.type == EditorEvents.LAYER_DEPTH:
 		var layer = layers.get_node(event.layer_name)
 		layer.set_depth(event.depth)
+
 	if event.type == EditorEvents.SET_BACKGROUND:
 		bg.set_bg(event.bg)
+
+func _set_tile(event: Dictionary, coords: Vector2i, coords_key: String, new_timestamp: int = -1) -> void:
+	var tilemap: TileMap = layers.get_node(event.layer_name + "/TileMap")
+	tilemap.set_cell(0, coords, 0, Helpers.to_atlas_coords(event.block_id))
+	
+	if new_timestamp != -1:
+		tile_update_timestamps[coords_key] = new_timestamp

--- a/client/singletons/helpers/Helpers.gd
+++ b/client/singletons/helpers/Helpers.gd
@@ -14,11 +14,11 @@ func get_base_ws_url() -> String:
 		
 	if '--local' in OS.get_cmdline_args() || OS.is_debug_build() || OS.get_environment('PR_ENV') == 'local' || OS.has_feature("editor"):
 		#return 'ws://localhost:8081/ws'
-		return 'ws://dev.platformracing.com/ws'
+		return 'ws://dev.platformracing.com/api/ws'
 	elif '--dev' in OS.get_cmdline_args() || OS.get_environment('PR_ENV') == 'dev':
-		return 'ws://dev.platformracing.com/ws'
+		return 'ws://dev.platformracing.com/api/ws'
 	else:
-		return 'ws://platformracing.com/ws'
+		return 'ws://platformracing.com/api/ws'
 		
 func get_base_url() -> String:
 	if OS.has_feature('web'):
@@ -29,11 +29,11 @@ func get_base_url() -> String:
 		
 	if '--local' in OS.get_cmdline_args() || OS.is_debug_build() || OS.get_environment('PR_ENV') == 'local' || OS.has_feature("editor"):
 		#return 'http://localhost:8080'
-		return 'https://dev.platformracing.com'
+		return 'https://dev.platformracing.com/api'
 	elif '--dev' in OS.get_cmdline_args() || OS.get_environment('PR_ENV') == 'dev':
-		return 'https://dev.platformracing.com'
+		return 'https://dev.platformracing.com/api'
 	else:
-		return 'https://platformracing.com'
+		return 'https://platformracing.com/api'
 
 func _get_current_level_name() -> String:
 	return current_level_name

--- a/client/singletons/helpers/Helpers.gd
+++ b/client/singletons/helpers/Helpers.gd
@@ -13,8 +13,13 @@ func get_base_ws_url() -> String:
 		return "ws://" + hostname
 		
 	if '--local' in OS.get_cmdline_args() || OS.is_debug_build() || OS.get_environment('PR_ENV') == 'local' || OS.has_feature("editor"):
+<<<<<<< HEAD
 		#return 'ws://localhost:8081/ws'
 		return 'ws://dev.platformracing.com/api/ws'
+=======
+		return 'ws://localhost:8081/ws'
+		#return 'ws://dev.platformracing.com/ws'
+>>>>>>> d86da4a (Remove lag when multiple people place blocks together in level editor)
 	elif '--dev' in OS.get_cmdline_args() || OS.get_environment('PR_ENV') == 'dev':
 		return 'ws://dev.platformracing.com/api/ws'
 	else:
@@ -28,8 +33,13 @@ func get_base_url() -> String:
 		return "https://" + hostname
 		
 	if '--local' in OS.get_cmdline_args() || OS.is_debug_build() || OS.get_environment('PR_ENV') == 'local' || OS.has_feature("editor"):
+<<<<<<< HEAD
 		#return 'http://localhost:8080'
 		return 'https://dev.platformracing.com/api'
+=======
+		return 'http://localhost:8080'
+		#return 'https://dev.platformracing.com'
+>>>>>>> d86da4a (Remove lag when multiple people place blocks together in level editor)
 	elif '--dev' in OS.get_cmdline_args() || OS.get_environment('PR_ENV') == 'dev':
 		return 'https://dev.platformracing.com/api'
 	else:

--- a/client/singletons/helpers/Helpers.gd
+++ b/client/singletons/helpers/Helpers.gd
@@ -13,17 +13,12 @@ func get_base_ws_url() -> String:
 		return "ws://" + hostname
 		
 	if '--local' in OS.get_cmdline_args() || OS.is_debug_build() || OS.get_environment('PR_ENV') == 'local' || OS.has_feature("editor"):
-<<<<<<< HEAD
 		#return 'ws://localhost:8081/ws'
-		return 'ws://dev.platformracing.com/api/ws'
-=======
-		return 'ws://localhost:8081/ws'
-		#return 'ws://dev.platformracing.com/ws'
->>>>>>> d86da4a (Remove lag when multiple people place blocks together in level editor)
+		return 'ws://dev.platformracing.com/gs/ws'
 	elif '--dev' in OS.get_cmdline_args() || OS.get_environment('PR_ENV') == 'dev':
-		return 'ws://dev.platformracing.com/api/ws'
+		return 'ws://dev.platformracing.com/gs/ws'
 	else:
-		return 'ws://platformracing.com/api/ws'
+		return 'ws://platformracing.com/gs/ws'
 		
 func get_base_url() -> String:
 	if OS.has_feature('web'):
@@ -33,13 +28,8 @@ func get_base_url() -> String:
 		return "https://" + hostname
 		
 	if '--local' in OS.get_cmdline_args() || OS.is_debug_build() || OS.get_environment('PR_ENV') == 'local' || OS.has_feature("editor"):
-<<<<<<< HEAD
 		#return 'http://localhost:8080'
 		return 'https://dev.platformracing.com/api'
-=======
-		return 'http://localhost:8080'
-		#return 'https://dev.platformracing.com'
->>>>>>> d86da4a (Remove lag when multiple people place blocks together in level editor)
 	elif '--dev' in OS.get_cmdline_args() || OS.get_environment('PR_ENV') == 'dev':
 		return 'https://dev.platformracing.com/api'
 	else:

--- a/client/singletons/session/Session.gd
+++ b/client/singletons/session/Session.gd
@@ -10,7 +10,6 @@ var _current_player_layer: String = ""
 var _username: String = Helpers.generate_username()
 var _used_rects: Dictionary = {}
 var _player_position: Vector2 = Vector2.ZERO
-var _local_edit_id = 0
 var _current_block_id = 0
 
 func _ready():
@@ -22,12 +21,6 @@ func set_current_block_id(value: int) -> void:
 
 func get_current_block_id() -> int:
 	return _current_block_id
-	
-func set_local_edit_id(value: int) -> void:
-	_local_edit_id = value
-
-func get_local_edit_id() -> int:
-	return _local_edit_id
 	
 func set_current_scene_name(value: String) -> void:
 	_current_scene_name = value

--- a/game-server/main.go
+++ b/game-server/main.go
@@ -138,8 +138,8 @@ func main() {
 
 	go handleMessages()
 
-	fmt.Println("PR4 Game Server started on :8081")
-	err := http.ListenAndServe(":8081", nil)
+	fmt.Println("PR4 Game Server started on :8080")
+	err := http.ListenAndServe(":8080", nil)
 	if err != nil {
 		panic("Error starting server: " + err.Error())
 	}


### PR DESCRIPTION
Hello, 

1. I noticed that your build-game-server.yaml file is currently set to build the "api" folder instead of the "game-server" folder. I’m not sure if this was intentional, but I wanted to point it out in case it wasn’t.

2. Additionally, I was wondering if there’s a way to reach you, perhaps via Discord? I would be very interested in contributing more to PR4 if you’re open to it.

3. Regarding what you mentioned about the Caddy server automatically adding the "api" path, I think what we can do for now is to change the "Helpers.gd" to simply add "api" path at the end for live and dev environment, but not for localhost. What do you think? 

5. Also, I am not sure if "ws://dev.platformracing.com/api/ws" request works so will need your help to double check this. I updated the api to use 8080 port and game-server to use 8081 port.