### PR TITLE
Fix zooming out and zoom amount in level editor, futureproof for custom zoom amounts, and fix a small warning.

### DIFF
--- a/client/pages/editor/editor_camera.gd
+++ b/client/pages/editor/editor_camera.gd
@@ -27,7 +27,7 @@ func _process(delta):
 	
 	if is_zooming:
 		var factor_to_zoom = target_zoom / camera_zoom
-		camera_zoom = lerp(camera_zoom, target_zoom, factor_to_zoom*delta*5)
+		camera_zoom = lerp(camera_zoom, target_zoom, max(factor_to_zoom, 1/factor_to_zoom)*delta*5)
 		if abs(factor_to_zoom - 1) < 0.001:
 			camera_zoom = target_zoom
 			is_zooming = false

--- a/client/pages/editor/zoom_panel/ZoomPicker.gd
+++ b/client/pages/editor/zoom_panel/ZoomPicker.gd
@@ -36,4 +36,4 @@ func _on_change():
 # 	NOTE - If in future this is changed to allow custom zoom amounts (variable name: zoom_amount), remove the line above and keep the code and comment below.
 #	if (typeof(zoom_amount) == 2 || typeof(zoom_amount) == 3): #Check if integer or float
 #		if not(is_nan(zoom_amount) || is_inf(zoom_amount) || zoom_amount == 0): #Disallow zero, NaN, and infinity (positive or negative)
-#			emit_signal("editor_camera_zoom_change", zoom_amount / 100.0)
+#			emit_signal("editor_camera_zoom_change", 0.5 * zoom_amount / 100.0)

--- a/client/pages/editor/zoom_panel/ZoomPicker.gd
+++ b/client/pages/editor/zoom_panel/ZoomPicker.gd
@@ -32,7 +32,7 @@ func _on_down_button_pressed():
 func _on_change():
 	zoom_increment = clamp(zoom_increment, min_zoom_increment, max_zoom_increment)
 	label.text = str(zoom_amounts[zoom_increment]) + "%"
-	emit_signal("editor_camera_zoom_change", zoom_amounts[zoom_increment] / 100.0)
+	emit_signal("editor_camera_zoom_change", 0.5 * zoom_amounts[zoom_increment] / 100.0)
 # 	NOTE - If in future this is changed to allow custom zoom amounts (variable name: zoom_amount), remove the line above and keep the code and comment below.
 #	if (typeof(zoom_amount) == 2 || typeof(zoom_amount) == 3): #Check if integer or float
 #		if not(is_nan(zoom_amount) || is_inf(zoom_amount) || zoom_amount == 0): #Disallow zero, NaN, and infinity (positive or negative)

--- a/client/pages/editor/zoom_panel/ZoomPicker.gd
+++ b/client/pages/editor/zoom_panel/ZoomPicker.gd
@@ -8,8 +8,8 @@ signal editor_camera_zoom_change
 
 var text: String = "%"
 var zoom_increment: int = 3
-var min: int = 0
-var max: int = 6
+var min_zoom_increment: int = 0
+var max_zoom_increment: int = 6
 var step: int = 1
 var zoom_amounts: Array = [25, 50, 75, 100, 150, 250, 500] #Zoom amounts listed in percentage.
 
@@ -30,6 +30,10 @@ func _on_down_button_pressed():
 
 
 func _on_change():
-	zoom_increment = clamp(zoom_increment, min, max)
+	zoom_increment = clamp(zoom_increment, min_zoom_increment, max_zoom_increment)
 	label.text = str(zoom_amounts[zoom_increment]) + "%"
 	emit_signal("editor_camera_zoom_change", zoom_amounts[zoom_increment] / 100.0)
+# 	NOTE - If in future this is changed to allow custom zoom amounts (variable name: zoom_amount), remove the line above and keep the code and comment below.
+#	if (typeof(zoom_amount) == 2 || typeof(zoom_amount) == 3): #Check if integer or float
+#		if not(is_nan(zoom_amount) || is_inf(zoom_amount) || zoom_amount == 0): #Disallow zero, NaN, and infinity (positive or negative)
+#			emit_signal("editor_camera_zoom_change", zoom_amount / 100.0)


### PR DESCRIPTION
There was a bug when I implemented zooming out in the level editor before, making it not snappy like it should be (zooming in was fine before and this update extends the intended behaviour to zooming out as well). I've also added commented out code for dealing with custom zoom amounts (if added), ready for if/when it's needed. Additionally, I changed a couple of variable names to remove the warning that min and max are also standard mathematical functions in Godot.